### PR TITLE
Modify library path

### DIFF
--- a/lib/ua_parser/source.rb
+++ b/lib/ua_parser/source.rb
@@ -19,7 +19,7 @@ module UAParser
     JS
 
     def self.path
-      @path ||= ENV['UA_PARSER_SOURCE_PATH'] || bundled_path
+      @path ||= Rails.root.join(ENV['UA_PARSER_SOURCE_PATH']) || bundled_path
     end
 
     def self.contents


### PR DESCRIPTION
Using an absolute path for UAParser.js is safer.